### PR TITLE
middleware.py uses WebOb, add it as a dependency in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ except ImportError:
 
 import sys
 
-install_requires = ["mako", "networkx", "PIL", "pygraphviz", 'Paste']
+install_requires = ["mako", "networkx", "PIL", "pygraphviz", 'Paste', 'WebOb']
 
 # ordereddict is required for versions < 2.7; its included in collections in
 # versions 2.7+ and 3.0+


### PR DESCRIPTION
Hi. It seems that the linesman middleware uses WebOb but the dependency is not declared in setup.py. This patch adds it.
