### PR TITLE
linesman doesn’t work with WebOb >= 1.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ except ImportError:
 
 import sys
 
-install_requires = ["mako", "networkx", "PIL", "pygraphviz", 'Paste', 'WebOb']
+install_requires = ["mako", "networkx", "PIL", "pygraphviz", 'Paste',
+                    'WebOb==1.1.1']
 
 # ordereddict is required for versions < 2.7; its included in collections in
 # versions 2.7+ and 3.0+


### PR DESCRIPTION
This patch is not a proper fix of the problem, but it could be a minimum diff.
