### PR TITLE
Fix an error raised when some node data are empty.

### DIFF
--- a/linesman/middleware.py
+++ b/linesman/middleware.py
@@ -413,6 +413,11 @@ def prepare_graph(source_graph, cutoff_time, break_cycles=False):
     # Always use a copy for destructive changes
     graph = source_graph.copy()
 
+    # Some node data could be empty dict
+    for node, data in graph.nodes(data=True):
+        if not data:
+            data['totaltime'] = 0
+
     max_totaltime = max(data['totaltime']
                         for node, data in graph.nodes(data=True))
     for node, data in graph.nodes(data=True):


### PR DESCRIPTION
Sometimes node data could be empty (for example, the application uses `gevent.spawn()` heavily, but I’m not sure why). In that case, several points of linesman raise `KeyError`.

It fixes node data to have `'totaltime'` key before graph data are used.
